### PR TITLE
Bump nanoid for CVE-2024-55565

### DIFF
--- a/package.json
+++ b/package.json
@@ -252,7 +252,7 @@
     "esm-env": "1.0.0",
     "fast-copy": "3.0.2",
     "fast-equals": "5.0.1",
-    "nanoid": "5.0.7",
+    "nanoid": "^5.0.9",
     "svelte-persisted-store": "0.11.0",
     "tweakpane": "4.0.4"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,8 +53,8 @@ importers:
         specifier: 5.0.1
         version: 5.0.1
       nanoid:
-        specifier: 5.0.7
-        version: 5.0.7
+        specifier: ^5.0.9
+        version: 5.0.9
       svelte-persisted-store:
         specifier: 0.11.0
         version: 0.11.0(svelte@4.2.19)
@@ -4210,8 +4210,8 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  nanoid@5.0.7:
-    resolution: {integrity: sha512-oLxFY2gd2IqnjcYyOXD8XGCftpGtZP2AbHbOkthDkvRywH5ayNtPVy9YlOPcHckXzbLTCHpkb7FB+yuxKV13pQ==}
+  nanoid@5.0.9:
+    resolution: {integrity: sha512-Aooyr6MXU6HpvvWXKoVoXwKMs/KyVakWwg7xQfv5/S/RIgJMy0Ifa45H9qqYy7pTCszrHzP21Uk4PZq2HpEM8Q==}
     engines: {node: ^18 || >=20}
     hasBin: true
 
@@ -11259,7 +11259,7 @@ snapshots:
 
   nanoid@3.3.7: {}
 
-  nanoid@5.0.7: {}
+  nanoid@5.0.9: {}
 
   natural-compare-lite@1.4.0: {}
 


### PR DESCRIPTION
Hello, thanks for all your work on this project! A low priority security alert popped up in our repository for `nanoid<5.0.9` pulled in by `svelte-tweakpane-ui`, which depends on `nanoid==5.0.7`. We like to close out our security alerts for compliance reasons.

This PR bumps the minimum version of `nanoid` to resolve the security alert, and widens the dependency range from exact to semver-compatible so that, in the future, there's no need to re-release `svelte-tweakpane-ui` to resolve this sorts of deep dependency issues.

(We're able to resolve this issue in our repository with a pnpm override, but I figured it was worth opening a quick PR just in case this was of interest to you, and because overrides can increase  maintenance burden over time)