### PR TITLE
Remove addListeners() on Color to fix janky hue slider

### DIFF
--- a/src/lib/control/Color.svelte
+++ b/src/lib/control/Color.svelte
@@ -142,17 +142,8 @@
 	// alpha to true on 0x00ffd6 doesn't add the control... were these both deprecated in 4.0?
 	// https://github.com/cocopon/tweakpane/issues/450 options.color.alpha, options.color.type
 
-	function addListeners() {
-		ref.on('change', () => {
-			// Issue where changes from the color picker swatch view aren't reflected in other
-			// controls on the same pane TODO figure this out...
-			ref.refresh()
-		})
-	}
-
 	$: value, updateInternalValueFromValue()
 	$: internalValue, updateValueFromInternalValue()
-	$: ref !== undefined && addListeners()
 	$: options = {
 		color: {
 			type,


### PR DESCRIPTION
Hello,

This change appears to fix #26. I didn't experience the problem mentioned by the comment, where other controls on the same pane don't reflect changes made in the swatch, maybe I'm missing something? There might be a better way to fix this issue -- I have a very limited understanding of Tweakpane. Thanks again for this project!