### PR TITLE
feat: Add draggable-absolute position Pane variation

### DIFF
--- a/src/lib/core/Pane.svelte
+++ b/src/lib/core/Pane.svelte
@@ -57,8 +57,6 @@
 	export let width: $$Props['width'] = undefined
 	export let tpPane: $$Props['tpPane'] = undefined
 
-	export let inertia: ComponentProps<InternalPaneDraggable>['inertia'] = false
-
 	// Redeclare types instead of referencing $$Props['key'] since certain keys aren't guaranteed
 	export let x: number | undefined = undefined
 	export let y: number | undefined = undefined
@@ -191,15 +189,7 @@ y={position === 'inline' ? undefined : 110}>
 -->
 {#if position === undefined || position === 'draggable'}
 	{#if BROWSER}
-		<InternalPaneDraggable
-			bind:expanded
-			bind:tpPane
-			bind:width
-			bind:x
-			bind:y
-			{inertia}
-			{...$$restProps}
-		>
+		<InternalPaneDraggable bind:expanded bind:tpPane bind:width bind:x bind:y {...$$restProps}>
 			<slot />
 		</InternalPaneDraggable>
 	{:else}
@@ -215,7 +205,6 @@ y={position === 'inline' ? undefined : 110}>
 			bind:width
 			bind:x
 			bind:y
-			{inertia}
 			{...DRAGGABLE_ABSOLUTE_PROPS}
 			{...$$restProps}
 		>

--- a/src/lib/core/Pane.svelte
+++ b/src/lib/core/Pane.svelte
@@ -57,6 +57,8 @@
 	export let width: $$Props['width'] = undefined
 	export let tpPane: $$Props['tpPane'] = undefined
 
+	export let inertia: ComponentProps<InternalPaneDraggable>['inertia'] = false
+
 	// Redeclare types instead of referencing $$Props['key'] since certain keys aren't guaranteed
 	export let x: number | undefined = undefined
 	export let y: number | undefined = undefined
@@ -189,7 +191,15 @@ y={position === 'inline' ? undefined : 110}>
 -->
 {#if position === undefined || position === 'draggable'}
 	{#if BROWSER}
-		<InternalPaneDraggable bind:expanded bind:tpPane bind:width bind:x bind:y {...$$restProps}>
+		<InternalPaneDraggable
+			bind:expanded
+			bind:tpPane
+			bind:width
+			bind:x
+			bind:y
+			{inertia}
+			{...$$restProps}
+		>
 			<slot />
 		</InternalPaneDraggable>
 	{:else}
@@ -205,6 +215,7 @@ y={position === 'inline' ? undefined : 110}>
 			bind:width
 			bind:x
 			bind:y
+			{inertia}
 			{...DRAGGABLE_ABSOLUTE_PROPS}
 			{...$$restProps}
 		>

--- a/src/lib/core/Pane.svelte
+++ b/src/lib/core/Pane.svelte
@@ -1,5 +1,5 @@
 <script context="module" lang="ts">
-	export type PanePosition = 'draggable' | 'fixed' | 'inline'
+	export type PanePosition = 'draggable' | 'draggable-absolute' | 'fixed' | 'inline'
 </script>
 
 <script lang="ts">
@@ -19,13 +19,16 @@
 		  })
 		// eslint-disable-next-line ts/no-duplicate-type-constituents, perfectionist/sort-union-types
 		| (ComponentProps<InternalPaneDraggable> & {
-				position?: 'draggable' | undefined
+				position?: 'draggable' | 'draggable-absolute' | undefined
 		  })
 	) & {
 		/**
 		 * Pane mode, one of three options:
 		 * - **'draggable'** *(default)*  \
 		 *   The pane is draggable and resizable, and may be placed anywhere over the page.
+		 * - **'draggable-absolute'** \
+		 *   Draggable + resizable overlay, but position is stored in document coordinates
+		 *   so the pane moves with the page during scroll.
 		 * - **'inline'**  \
 		 *   The pane appears inline with other content in the normal flow of the document.  \
 		 *   This is the default mode for components created outside of an explicit `<Pane>`
@@ -71,6 +74,9 @@
 
 	// The below proved more reliable than keying on mode and setting <svelte:component
 	// this={props.mode} {...$$restProps} />
+
+	// Potentially a better way to pass props
+	const DRAGGABLE_ABSOLUTE_PROPS = { useScrollCoordinates: true } as const
 </script>
 
 <!--
@@ -115,6 +121,13 @@ Position mode overview:
   Double-clicking the width drag handle will expand or contract the pane between to its `minWidth`
   and `maxWidth` sizes.
 
+  - **`<Pane position="draggable-absolute" ...>`**  \
+	Like `draggable`, but behaves as if absolutely positioned in the document: `x/y` are stored in
+  document coordinates so the pane moves with the page while scrolling.  
+      \
+  Internally, the pane is rendered as `position: fixed` to avoid affecting layout or overflow, with its
+  viewport coordinates converted to document coordinates using the current scroll position.
+
 - **`<Pane position="inline" ...>`**  \
     Provides an inline version of the pane component, allowing the Tweakpane window to appear in the
   normal flow of the document.  
@@ -136,11 +149,13 @@ Position mode overview:
 <script lang="ts">
   import { Pane, type PanePosition, RadioGrid } from 'svelte-tweakpane-ui'
 
-  const options: PanePosition[] = ['inline', 'fixed', 'draggable']
+  const options: PanePosition[] = ['inline', 'fixed', 'draggable', 'draggable-absolute']
   let position: PanePosition = options[0]
 </script>
 
-<Pane {position} title="Pane" y={position === 'inline' ? undefined : 110}>
+<Pane {position} title="Pane" 
+x={position === 'inline' ? undefined : Math.round(window.innerWidth / 2 - 200)} 
+y={position === 'inline' ? undefined : 110}>
   <RadioGrid
     bind:value={position}
     columns={1}
@@ -151,7 +166,9 @@ Position mode overview:
 {#if position === 'fixed'}
   <p>Pane is fixed at the top-right of the page.</p>
 {:else if position === 'draggable'}
-  <p>Pane is draggable at the top-right of the page.</p>
+  <p>Pane is draggable at the top of the page.</p>
+{:else if position === 'draggable-absolute'}
+  <p>Pane is draggable-absolute at the top of the page.</p>
 {/if}
 
 <style>
@@ -173,6 +190,24 @@ Position mode overview:
 {#if position === undefined || position === 'draggable'}
 	{#if BROWSER}
 		<InternalPaneDraggable bind:expanded bind:tpPane bind:width bind:x bind:y {...$$restProps}>
+			<slot />
+		</InternalPaneDraggable>
+	{:else}
+		<div style="display: none;">
+			<slot />
+		</div>
+	{/if}
+{:else if position === 'draggable-absolute'}
+	{#if BROWSER}
+		<InternalPaneDraggable
+			bind:expanded
+			bind:tpPane
+			bind:width
+			bind:x
+			bind:y
+			{...DRAGGABLE_ABSOLUTE_PROPS}
+			{...$$restProps}
+		>
 			<slot />
 		</InternalPaneDraggable>
 	{:else}

--- a/src/lib/internal/InternalPaneDraggable.svelte
+++ b/src/lib/internal/InternalPaneDraggable.svelte
@@ -29,6 +29,79 @@
 	// optional but with a default value in the $$Props type
 	type $$Props = Omit<ComponentProps<GenericPane>, 'userCreatedPane'> & {
 		/**
+		 * Automatically collapse open panels when the available window size is less than the height
+		 * of the pane.
+		 * @default `false`
+		 */
+		collapseChildrenToFit?: boolean
+		/**
+		 * Adds inertial motion after drag release.
+		 *
+		 * - `true` enables with defaults: `friction: 8`, `bounce: 0`
+		 * - `inertia={{ friction, bounce }}` customises
+		 *
+		 * Tuning:
+		 * - `friction`: 0 = no slowdown, higher = stops faster (typical 4–16)
+		 * - `bounce`: 0 = no bounce, 1 = perfectly elastic (typical 0–0.6)
+		 * @default `false`
+		 */
+		inertia?: boolean | { bounce?: number; friction?: number }
+		/**
+		 * Identifier to be used if multiple `<Pane position="draggable">` components with
+		 * `storePositionLocally` set to true are used on the same page.
+		 * @default `'1'`
+		 */
+		localStoreId?: string
+		/**
+		 * Maximum pane width in pixels.
+		 * @default `600`
+		 */
+		maxWidth?: number
+		/**
+		 * Minimum pane width in pixels.
+		 * @default `200`
+		 */
+		minWidth?: number
+		/**
+		 * CSS [padding property string](https://developer.mozilla.org/en-US/docs/Web/CSS/padding)
+		 * to apply to the draggable pane container to prevent it from being dragged all the way to
+		 * the edge of the window.
+		 *
+		 * Useful for keeping the pane away from of menu bars, etc.
+		 * @default `'0'`
+		 */
+		padding?: string
+		/**
+		 * Allow the user to resize the width of the pane by dragging the right corner of the title
+		 * bar.
+		 * @default `true`
+		 */
+		resizable?: boolean
+		/**
+		 * Store the pane's position and width when the user changes it interactively.
+		 *
+		 * Set the `localStoreId` prop if you have multiple draggable panes on the same page with
+		 * `storePositionLocally` set to `true`.
+		 * @default `true`
+		 */
+		storePositionLocally?: boolean
+		/**
+		 * Width of the pane, in pixels.
+		 *
+		 * Setting explicitly via a passed prop will override saved user-specified width.
+		 *
+		 * Use this prop to set a starting width, or to monitor changes in the the pane's width when
+		 * a user resizes it.
+		 *
+		 * Note that height is not exposed because it is determined dynamically by the pane's
+		 * contents and state of its foldable elements.
+		 *
+		 * By default, the width value is saved to local storage for persistence across page loads.
+		 * @default `256`
+		 * @bindable
+		 */
+		width?: number
+		/**
 		 * Horizontal position of the pane relative to the left edge of the window, in pixels.
 		 *
 		 * Not to be confused with the `position` prop which defines _how_, not _where_, the pane is
@@ -50,67 +123,6 @@
 		 * @bindable
 		 */
 		y?: number
-		/**
-		 * Width of the pane, in pixels.
-		 *
-		 * Setting explicitly via a passed prop will override saved user-specified width.
-		 *
-		 * Use this prop to set a starting width, or to monitor changes in the the pane's width when
-		 * a user resizes it.
-		 *
-		 * Note that height is not exposed because it is determined dynamically by the pane's
-		 * contents and state of its foldable elements.
-		 *
-		 * By default, the width value is saved to local storage for persistence across page loads.
-		 * @default `256`
-		 * @bindable
-		 */
-		width?: number
-		/**
-		 * Minimum pane width in pixels.
-		 * @default `200`
-		 */
-		minWidth?: number
-		/**
-		 * Maximum pane width in pixels.
-		 * @default `600`
-		 */
-		maxWidth?: number
-		/**
-		 * Allow the user to resize the width of the pane by dragging the right corner of the title
-		 * bar.
-		 * @default `true`
-		 */
-		resizable?: boolean
-		/**
-		 * CSS [padding property string](https://developer.mozilla.org/en-US/docs/Web/CSS/padding)
-		 * to apply to the draggable pane container to prevent it from being dragged all the way to
-		 * the edge of the window.
-		 *
-		 * Useful for keeping the pane away from of menu bars, etc.
-		 * @default `'0'`
-		 */
-		padding?: string
-		/**
-		 * Automatically collapse open panels when the available window size is less than the height
-		 * of the pane.
-		 * @default `false`
-		 */
-		collapseChildrenToFit?: boolean
-		/**
-		 * Store the pane's position and width when the user changes it interactively.
-		 *
-		 * Set the `localStoreId` prop if you have multiple draggable panes on the same page with
-		 * `storePositionLocally` set to `true`.
-		 * @default `true`
-		 */
-		storePositionLocally?: boolean
-		/**
-		 * Identifier to be used if multiple `<Pane position="draggable">` components with
-		 * `storePositionLocally` set to true are used on the same page.
-		 * @default `'1'`
-		 */
-		localStoreId?: string
 	}
 
 	type $$Slots = {
@@ -178,6 +190,95 @@
 				syncScroll()
 			})
 		}
+	}
+
+	export let inertia: $$Props['inertia'] = false
+
+	//Inertia Logic
+	let vx = 0
+	let vy = 0
+	let sx = 0
+	let sy = 0
+	let lastMoveTime = 0
+
+	let inertiaRaf = 0
+
+	// Cancel any existing inertia loop and reset velocity
+	function stopInertia() {
+		if (inertiaRaf) cancelAnimationFrame(inertiaRaf)
+		inertiaRaf = 0
+		vx = 0
+		vy = 0
+		sx = x ?? sx
+		sy = y ?? sy
+	}
+
+	function startInertia() {
+		if (!inertia) return
+		if (!documentWidth || !documentHeight) return
+
+		// Set default values if no object provided
+		const friction = inertia === true ? 8 : (inertia.friction ?? 8)
+		const bounce = inertia === true ? 0 : (inertia.bounce ?? 0)
+
+		// Small threshold so a tiny release doesn't drift
+		if (Math.hypot(vx, vy) < 20) {
+			vx = 0
+			vy = 0
+			return
+		}
+		// Cancel any existing inertia loop whilst keeping current velocity
+		if (inertiaRaf) cancelAnimationFrame(inertiaRaf)
+		inertiaRaf = 0
+		let lastStep = performance.now()
+		// Seed sim state from current rendered state
+		sx = x ?? 0
+		sy = y ?? 0
+		const inertiaStep = (now: number) => {
+			// Clamp dt to prevent huge jumps/spikes when Raf hiccups (tab switch/dropped frames)
+			const dt = Math.min(0.05, (now - lastStep) / 1000) // Max 50ms
+			lastStep = now
+			// Integrate sim state
+			sx += vx * dt
+			sy += vy * dt
+			if (bounce && bounce > 0) {
+				// Fixed bounds
+				let minX = 0
+				let minY = 0
+				let maxX = Math.max(0, documentWidth - containerWidth)
+				let maxY = Math.max(0, documentHeight - containerHeightScaled)
+				// If absolute, update bounds to consider offsetParent and scroll
+
+				if (sx < minX) {
+					sx = minX
+					vx = -vx * bounce
+				} else if (sx > maxX) {
+					sx = maxX
+					vx = -vx * bounce
+				}
+				if (sy < minY) {
+					sy = minY
+					vy = -vy * bounce
+				} else if (sy > maxY) {
+					sy = maxY
+					vy = -vy * bounce
+				}
+			}
+			// Friction / velocity decay
+			const decay = Math.exp(-Math.max(0, friction) * dt) // 0 = frictionless, 10 = snappy
+			vx *= decay
+			vy *= decay
+			// Use device pixels for consistency across different zoom levels and resolutions
+			const devicePxPerFrame = Math.hypot(vx, vy) * dt * devicePixelRatio
+			// Snap simulated position to device pixels for rendering
+			const step = 1 / devicePixelRatio
+			x = Math.round(sx / step) * step
+			y = Math.round(sy / step) * step
+			// Stop when effectively not moving
+			if (devicePxPerFrame < 0.01) return stopInertia()
+			inertiaRaf = requestAnimationFrame(inertiaStep)
+		}
+		inertiaRaf = requestAnimationFrame(inertiaStep)
 	}
 
 	let containerElement: HTMLDivElement
@@ -298,6 +399,11 @@
 		) {
 			moveDistance = 0
 
+			if (inertia) {
+				stopInertia()
+				lastMoveTime = performance.now()
+			}
+
 			// Remove down listeners, prevents drag-related multi-touch
 			// Can revisit this with a more robust approach...
 			initialDragEvent = event
@@ -348,6 +454,9 @@
 			if (event.target === dragBarElement) {
 				moveDistance += Math.hypot(event.movementX, event.movementY)
 
+				const previousX = x
+				const previousY = y
+
 				if (useScrollCoordinates) {
 					// Drag in viewport space, then add scroll to convert back to document coords
 					x = event.clientX + startOffsetX + scrollX
@@ -356,6 +465,38 @@
 					// Drag entirely in viewport space
 					x = event.clientX + startOffsetX
 					y = event.clientY + startOffsetY
+				}
+
+				//Calculate inertia velocity for when releasing drag
+				if (inertia) {
+					const now = performance.now()
+					// Caps dt stalls at 50ms
+					const dt = Math.min(0.05, (now - lastMoveTime) / 1000)
+					// Calculate applied movement
+					const dx = x - previousX
+					const dy = y - previousY
+					lastMoveTime = now
+
+					// Treat tiny movement as "stopped" so we don't carry momentum when still
+					if (Math.abs(dx) < 0.25 && Math.abs(dy) < 0.25) {
+						vx = 0
+						vy = 0
+						return
+					}
+					const newVx = dx / dt
+					const newVy = dy / dt
+					// Smooth velocity over multiple frames to kill spikes/jitter in pointer sampling
+					const alpha = 0.35
+					vx += (newVx - vx) * alpha
+					vy += (newVy - vy) * alpha
+					//Cap max inital velocity
+					const speed = Math.hypot(vx, vy)
+					const maxSpeed = 20_000
+					if (speed > maxSpeed) {
+						const s = maxSpeed / speed
+						vx *= s
+						vy *= s
+					}
 				}
 			} else if (event.target === widthHandleElement) {
 				width = clamp(event.pageX + startOffsetX + startWidth - x, minWidth, maxAvailablePanelWidth)
@@ -418,6 +559,24 @@
 				tpPane
 			) {
 				tpPane.expanded = !tpPane.expanded
+			}
+
+			if (
+				inertia &&
+				event.type === 'pointerup' &&
+				event.target === dragBarElement &&
+				moveDistance >= dragMovementDistanceThreshold
+			) {
+				//If havent moved in 80ms set velocity to 0 (prevents stale velocity from dragMove)
+				if (performance.now() - lastMoveTime > 80) {
+					vx = 0
+					vy = 0
+				}
+				startInertia()
+			} else {
+				// Reset any stale velocity
+				vx = 0
+				vy = 0
 			}
 
 			initialDragEvent = undefined

--- a/src/lib/internal/InternalPaneDraggable.svelte
+++ b/src/lib/internal/InternalPaneDraggable.svelte
@@ -29,79 +29,6 @@
 	// optional but with a default value in the $$Props type
 	type $$Props = Omit<ComponentProps<GenericPane>, 'userCreatedPane'> & {
 		/**
-		 * Automatically collapse open panels when the available window size is less than the height
-		 * of the pane.
-		 * @default `false`
-		 */
-		collapseChildrenToFit?: boolean
-		/**
-		 * Adds inertial motion after drag release.
-		 *
-		 * - `true` enables with defaults: `friction: 8`, `bounce: 0`
-		 * - `inertia={{ friction, bounce }}` customises
-		 *
-		 * Tuning:
-		 * - `friction`: 0 = no slowdown, higher = stops faster (typical 4–16)
-		 * - `bounce`: 0 = no bounce, 1 = perfectly elastic (typical 0–0.6)
-		 * @default `false`
-		 */
-		inertia?: boolean | { bounce?: number; friction?: number }
-		/**
-		 * Identifier to be used if multiple `<Pane position="draggable">` components with
-		 * `storePositionLocally` set to true are used on the same page.
-		 * @default `'1'`
-		 */
-		localStoreId?: string
-		/**
-		 * Maximum pane width in pixels.
-		 * @default `600`
-		 */
-		maxWidth?: number
-		/**
-		 * Minimum pane width in pixels.
-		 * @default `200`
-		 */
-		minWidth?: number
-		/**
-		 * CSS [padding property string](https://developer.mozilla.org/en-US/docs/Web/CSS/padding)
-		 * to apply to the draggable pane container to prevent it from being dragged all the way to
-		 * the edge of the window.
-		 *
-		 * Useful for keeping the pane away from of menu bars, etc.
-		 * @default `'0'`
-		 */
-		padding?: string
-		/**
-		 * Allow the user to resize the width of the pane by dragging the right corner of the title
-		 * bar.
-		 * @default `true`
-		 */
-		resizable?: boolean
-		/**
-		 * Store the pane's position and width when the user changes it interactively.
-		 *
-		 * Set the `localStoreId` prop if you have multiple draggable panes on the same page with
-		 * `storePositionLocally` set to `true`.
-		 * @default `true`
-		 */
-		storePositionLocally?: boolean
-		/**
-		 * Width of the pane, in pixels.
-		 *
-		 * Setting explicitly via a passed prop will override saved user-specified width.
-		 *
-		 * Use this prop to set a starting width, or to monitor changes in the the pane's width when
-		 * a user resizes it.
-		 *
-		 * Note that height is not exposed because it is determined dynamically by the pane's
-		 * contents and state of its foldable elements.
-		 *
-		 * By default, the width value is saved to local storage for persistence across page loads.
-		 * @default `256`
-		 * @bindable
-		 */
-		width?: number
-		/**
 		 * Horizontal position of the pane relative to the left edge of the window, in pixels.
 		 *
 		 * Not to be confused with the `position` prop which defines _how_, not _where_, the pane is
@@ -123,6 +50,67 @@
 		 * @bindable
 		 */
 		y?: number
+		/**
+		 * Width of the pane, in pixels.
+		 *
+		 * Setting explicitly via a passed prop will override saved user-specified width.
+		 *
+		 * Use this prop to set a starting width, or to monitor changes in the the pane's width when
+		 * a user resizes it.
+		 *
+		 * Note that height is not exposed because it is determined dynamically by the pane's
+		 * contents and state of its foldable elements.
+		 *
+		 * By default, the width value is saved to local storage for persistence across page loads.
+		 * @default `256`
+		 * @bindable
+		 */
+		width?: number
+		/**
+		 * Minimum pane width in pixels.
+		 * @default `200`
+		 */
+		minWidth?: number
+		/**
+		 * Maximum pane width in pixels.
+		 * @default `600`
+		 */
+		maxWidth?: number
+		/**
+		 * Allow the user to resize the width of the pane by dragging the right corner of the title
+		 * bar.
+		 * @default `true`
+		 */
+		resizable?: boolean
+		/**
+		 * CSS [padding property string](https://developer.mozilla.org/en-US/docs/Web/CSS/padding)
+		 * to apply to the draggable pane container to prevent it from being dragged all the way to
+		 * the edge of the window.
+		 *
+		 * Useful for keeping the pane away from of menu bars, etc.
+		 * @default `'0'`
+		 */
+		padding?: string
+		/**
+		 * Automatically collapse open panels when the available window size is less than the height
+		 * of the pane.
+		 * @default `false`
+		 */
+		collapseChildrenToFit?: boolean
+		/**
+		 * Store the pane's position and width when the user changes it interactively.
+		 *
+		 * Set the `localStoreId` prop if you have multiple draggable panes on the same page with
+		 * `storePositionLocally` set to `true`.
+		 * @default `true`
+		 */
+		storePositionLocally?: boolean
+		/**
+		 * Identifier to be used if multiple `<Pane position="draggable">` components with
+		 * `storePositionLocally` set to true are used on the same page.
+		 * @default `'1'`
+		 */
+		localStoreId?: string
 	}
 
 	type $$Slots = {
@@ -190,95 +178,6 @@
 				syncScroll()
 			})
 		}
-	}
-
-	export let inertia: $$Props['inertia'] = false
-
-	//Inertia Logic
-	let vx = 0
-	let vy = 0
-	let sx = 0
-	let sy = 0
-	let lastMoveTime = 0
-
-	let inertiaRaf = 0
-
-	// Cancel any existing inertia loop and reset velocity
-	function stopInertia() {
-		if (inertiaRaf) cancelAnimationFrame(inertiaRaf)
-		inertiaRaf = 0
-		vx = 0
-		vy = 0
-		sx = x ?? sx
-		sy = y ?? sy
-	}
-
-	function startInertia() {
-		if (!inertia) return
-		if (!documentWidth || !documentHeight) return
-
-		// Set default values if no object provided
-		const friction = inertia === true ? 8 : (inertia.friction ?? 8)
-		const bounce = inertia === true ? 0 : (inertia.bounce ?? 0)
-
-		// Small threshold so a tiny release doesn't drift
-		if (Math.hypot(vx, vy) < 20) {
-			vx = 0
-			vy = 0
-			return
-		}
-		// Cancel any existing inertia loop whilst keeping current velocity
-		if (inertiaRaf) cancelAnimationFrame(inertiaRaf)
-		inertiaRaf = 0
-		let lastStep = performance.now()
-		// Seed sim state from current rendered state
-		sx = x ?? 0
-		sy = y ?? 0
-		const inertiaStep = (now: number) => {
-			// Clamp dt to prevent huge jumps/spikes when Raf hiccups (tab switch/dropped frames)
-			const dt = Math.min(0.05, (now - lastStep) / 1000) // Max 50ms
-			lastStep = now
-			// Integrate sim state
-			sx += vx * dt
-			sy += vy * dt
-			if (bounce && bounce > 0) {
-				// Fixed bounds
-				let minX = 0
-				let minY = 0
-				let maxX = Math.max(0, documentWidth - containerWidth)
-				let maxY = Math.max(0, documentHeight - containerHeightScaled)
-				// If absolute, update bounds to consider offsetParent and scroll
-
-				if (sx < minX) {
-					sx = minX
-					vx = -vx * bounce
-				} else if (sx > maxX) {
-					sx = maxX
-					vx = -vx * bounce
-				}
-				if (sy < minY) {
-					sy = minY
-					vy = -vy * bounce
-				} else if (sy > maxY) {
-					sy = maxY
-					vy = -vy * bounce
-				}
-			}
-			// Friction / velocity decay
-			const decay = Math.exp(-Math.max(0, friction) * dt) // 0 = frictionless, 10 = snappy
-			vx *= decay
-			vy *= decay
-			// Use device pixels for consistency across different zoom levels and resolutions
-			const devicePxPerFrame = Math.hypot(vx, vy) * dt * devicePixelRatio
-			// Snap simulated position to device pixels for rendering
-			const step = 1 / devicePixelRatio
-			x = Math.round(sx / step) * step
-			y = Math.round(sy / step) * step
-			// Stop when effectively not moving
-			if (devicePxPerFrame < 0.01) return stopInertia()
-			inertiaRaf = requestAnimationFrame(inertiaStep)
-		}
-		inertiaRaf = requestAnimationFrame(inertiaStep)
 	}
 
 	let containerElement: HTMLDivElement
@@ -399,11 +298,6 @@
 		) {
 			moveDistance = 0
 
-			if (inertia) {
-				stopInertia()
-				lastMoveTime = performance.now()
-			}
-
 			// Remove down listeners, prevents drag-related multi-touch
 			// Can revisit this with a more robust approach...
 			initialDragEvent = event
@@ -454,9 +348,6 @@
 			if (event.target === dragBarElement) {
 				moveDistance += Math.hypot(event.movementX, event.movementY)
 
-				const previousX = x
-				const previousY = y
-
 				if (useScrollCoordinates) {
 					// Drag in viewport space, then add scroll to convert back to document coords
 					x = event.clientX + startOffsetX + scrollX
@@ -465,38 +356,6 @@
 					// Drag entirely in viewport space
 					x = event.clientX + startOffsetX
 					y = event.clientY + startOffsetY
-				}
-
-				//Calculate inertia velocity for when releasing drag
-				if (inertia) {
-					const now = performance.now()
-					// Caps dt stalls at 50ms
-					const dt = Math.min(0.05, (now - lastMoveTime) / 1000)
-					// Calculate applied movement
-					const dx = x - previousX
-					const dy = y - previousY
-					lastMoveTime = now
-
-					// Treat tiny movement as "stopped" so we don't carry momentum when still
-					if (Math.abs(dx) < 0.25 && Math.abs(dy) < 0.25) {
-						vx = 0
-						vy = 0
-						return
-					}
-					const newVx = dx / dt
-					const newVy = dy / dt
-					// Smooth velocity over multiple frames to kill spikes/jitter in pointer sampling
-					const alpha = 0.35
-					vx += (newVx - vx) * alpha
-					vy += (newVy - vy) * alpha
-					//Cap max inital velocity
-					const speed = Math.hypot(vx, vy)
-					const maxSpeed = 20_000
-					if (speed > maxSpeed) {
-						const s = maxSpeed / speed
-						vx *= s
-						vy *= s
-					}
 				}
 			} else if (event.target === widthHandleElement) {
 				width = clamp(event.pageX + startOffsetX + startWidth - x, minWidth, maxAvailablePanelWidth)
@@ -559,24 +418,6 @@
 				tpPane
 			) {
 				tpPane.expanded = !tpPane.expanded
-			}
-
-			if (
-				inertia &&
-				event.type === 'pointerup' &&
-				event.target === dragBarElement &&
-				moveDistance >= dragMovementDistanceThreshold
-			) {
-				//If havent moved in 80ms set velocity to 0 (prevents stale velocity from dragMove)
-				if (performance.now() - lastMoveTime > 80) {
-					vx = 0
-					vy = 0
-				}
-				startInertia()
-			} else {
-				// Reset any stale velocity
-				vx = 0
-				vy = 0
 			}
 
 			initialDragEvent = undefined

--- a/src/lib/internal/InternalPaneDraggable.svelte
+++ b/src/lib/internal/InternalPaneDraggable.svelte
@@ -159,6 +159,7 @@
 	export let useScrollCoordinates = false
 	let scrollX = 0
 	let scrollY = 0
+	let scrollPending = false
 
 	const syncScroll = () => {
 		scrollX = window.scrollX
@@ -168,7 +169,15 @@
 	const onScroll = () => {
 		// Don't update scroll when dragging
 		if (initialDragEvent) return
-		syncScroll()
+		if (!scrollPending) {
+			scrollPending = true
+
+			// Coalesce scroll events
+			requestAnimationFrame(() => {
+				scrollPending = false
+				syncScroll()
+			})
+		}
 	}
 
 	let containerElement: HTMLDivElement

--- a/src/lib/internal/InternalPaneDraggable.svelte
+++ b/src/lib/internal/InternalPaneDraggable.svelte
@@ -500,7 +500,10 @@
 			addDragStartListeners()
 		}
 
-		if (useScrollCoordinates) window.addEventListener('scroll', onScroll, { passive: true })
+		if (useScrollCoordinates) {
+			syncScroll()
+			window.addEventListener('scroll', onScroll, { passive: true })
+		}
 	})
 
 	onDestroy(() => {

--- a/src/lib/internal/InternalPaneDraggable.svelte
+++ b/src/lib/internal/InternalPaneDraggable.svelte
@@ -559,11 +559,13 @@
 		minWidth !== undefined &&
 		maxWidth !== undefined
 	) {
+		// Collapse children if needed TODO progressive collapsing not working because of container
+		// height update delays...
 		if (collapseChildrenToFit && containerHeightScaled > documentHeight && tpPane) {
 			recursiveCollapse(tpPane.children)
 		}
 
-		// Clamp x/y directly (they are either viewport coords or document coords depending on mode)
+		// Prioritize visibility of the top / left corner
 		x = clamp(x, 0, Math.max(0, documentWidth - containerWidth))
 		y = clamp(y, 0, Math.max(0, documentHeight - containerHeightScaled))
 


### PR DESCRIPTION
Adds draggable-absolute position to the core Pane component via internal flag on InternalPaneDraggable. Emulates absolute position on fixed pane via offsetting by the scroll position. 

## Additional changes:


1.  small optimisation/simplification on the default draggable path
```ts
x = event.pageX + startOffsetX - (window.scrollX - startScrollX)
y = event.pageY + startOffsetY - (window.scrollY - startScrollY)
```
to
```ts
x = event.clientX + startOffsetX
y = event.clientY + startOffsetY
```
this keeps dragging smooth whilst scrolling without having to read the window scroll position at all on the fixed path. If there was a reason for using page coordinates this can be reverted, but with this, scroll position only needs to be listened to on the absolute path and both paths aren't affected by scrolling whilst dragging.

---

2. There's a bug on the docs where the draggable pane example gets stuck in the top right under the table of contents so it cant be dragged or changed without refreshing the page.

I've added a draggable-absolute option to the docs example script and tried to fix this by doing

```svelte
<Pane {position} title="Pane" 
x={position === 'inline' ? undefined : Math.round(window.innerWidth / 2 - 200)} 
y={position === 'inline' ? undefined : 110}>
```
so hopefully its more centred and doesn't get stuck behind anything but note im unable to build the docs site on my machine so I haven't been able to verify how this looks.

---

Overall, the changes are pretty clean but I am unsure how to properly handle the props/types as im unfamiliar with svelte2tsx or whatever unique setup is going on.

for now in order to get it to build i've handled the new internal props like so

InternalPaneDraggable.svelte:
```ts	
/** @internal */
export let useScrollCoordinates = false
let scrollX = 0
let scrollY = 0
```
Pane.svelte
```svelte
<script lang="ts">
	const DRAGGABLE_ABSOLUTE_PROPS = { useScrollCoordinates: true } as const
</script>

<InternalPaneDraggable
	bind:expanded
	bind:tpPane
	bind:width
	bind:x
	bind:y
	{...DRAGGABLE_ABSOLUTE_PROPS}
	{...$$restProps}
>
	<slot />
</InternalPaneDraggable>

```

If there's a better way to handle the props/types or any improved naming suggestions please let me know, thanks.