### PR TITLE
feat: Add support for `number` value type in `<Color>` component

### DIFF
--- a/docs/src/content/docs/docs/index.mdx
+++ b/docs/src/content/docs/docs/index.mdx
@@ -252,7 +252,7 @@ The vanilla tweakpane API is highly dynamic, and the availability of various opt
 
 Svelte's component API is comparatively static, and the availability of props is typically fixed at compile time... but several _Svelte Tweakpane UI_ components feature dynamic properties that are added / removed from the component depending on the presence or type of other props.
 
-Dynamic props are used in cases where the clarity of a component's purpose isn't compromised by a bit of dynamism (e.g. `<Pane>`), or where the alternative would be to create a large number of very similar components (e.g. `<Monitor>`).
+Dynamic props are used in cases where the clarity of a component's purpose isn't compromised by a bit of dynamism (e.g. `<Pane>`), where the alternative would be to create a large number of very similar components (e.g. `<Monitor>`), or where a prop would otherwise be [silently ignored](https://github.com/cocopon/tweakpane/issues/626) for certain value types (e.g. `<Color>`'s `alpha` prop, which only applies to number values).
 
 Svelte's approach to supporting dynamic props is still evolving, and the right balance between flexibility and predictability is subject to reconsideration in subsequent versions of Svelte Tweakpane UI.
 

--- a/scripts/generate-documentation-data.ts
+++ b/scripts/generate-documentation-data.ts
@@ -102,7 +102,8 @@ export async function generateDocumentationData(): Promise<void> {
 							condition: {
 								value: 1,
 							},
-							description: '`value` is of type `number`',
+							description:
+								'`value` is of type `number`, since `string`, `object`, and `tuple` values carry their own alpha information',
 						},
 						{
 							condition: {
@@ -114,13 +115,14 @@ export async function generateDocumentationData(): Promise<void> {
 							condition: {
 								value: '{{ r: 0, g: 0, b: 0 }}',
 							},
-							description: '`value` is an object',
+							description: '`value` is an `object`',
 						},
 						{
 							condition: {
 								value: '{[0, 0, 0]}',
 							},
-							description: '`value` is a tuple',
+							description:
+								'`value` is a `tuple`, since `string` values carry their own type information and `number` values are always treated as integers',
 						},
 					]
 

--- a/scripts/generate-documentation-data.ts
+++ b/scripts/generate-documentation-data.ts
@@ -96,6 +96,37 @@ export async function generateDocumentationData(): Promise<void> {
 			let testProps: ComponentDynamicPropTest[] | undefined
 
 			switch (name) {
+				case 'Color': {
+					testProps = [
+						{
+							condition: {
+								value: 1,
+							},
+							description: '`value` is of type `number`',
+						},
+						{
+							condition: {
+								value: '#ff00ff',
+							},
+							description: '`value` is of type `string`',
+						},
+						{
+							condition: {
+								value: '{{ r: 0, g: 0, b: 0 }}',
+							},
+							description: '`value` is an object',
+						},
+						{
+							condition: {
+								value: '{[0, 0, 0]}',
+							},
+							description: '`value` is a tuple',
+						},
+					]
+
+					break
+				}
+
 				case 'Monitor': {
 					testProps = [
 						{

--- a/src/examples/tests/TestColor.svelte
+++ b/src/examples/tests/TestColor.svelte
@@ -1,8 +1,15 @@
 <script lang="ts">
-	import { Color, type ColorValueRgbaTuple, type ColorValueRgbObject } from '$lib'
+	import {
+		Color,
+		type ColorValueNumber,
+		type ColorValueRgbaTuple,
+		type ColorValueRgbObject,
+	} from '$lib'
 
 	let value: ColorValueRgbObject = { r: 0, g: 0, b: 0 }
 	let value2: ColorValueRgbaTuple = [0, 0, 0, 0]
+	let value3: ColorValueNumber = 0xff_66_00
+	let value4: ColorValueNumber = 0x00_ff_d6_44
 
 	let binding1InternalEventCount = 0
 	let binding1ExternalEventCount = 0
@@ -59,6 +66,9 @@
 	}}
 />
 
+<Color label="Binding 5" bind:value={value3} />
+<Color alpha={true} label="Binding 6" bind:value={value4} />
+
 <hr />
 
 <pre>Value Object: <span>{JSON.stringify(value, undefined, 2)}</span></pre>
@@ -71,4 +81,7 @@
 <pre>Binding 3 Internal: <span>{binding3InternalEventCount}</span></pre>
 <pre>Binding 3 External: <span>{binding3ExternalEventCount}</span></pre>
 <pre>Binding 4 Internal: <span>{binding4InternalEventCount}</span></pre>
-<pre>Binding 5 External: <span>{binding4ExternalEventCount}</span></pre>
+<pre>Binding 4 External: <span>{binding4ExternalEventCount}</span></pre>
+
+<pre>Value Number: <span>{value3}</span></pre>
+<pre>Value Number Alpha: <span>{value4}</span></pre>

--- a/src/lib/control/Color.svelte
+++ b/src/lib/control/Color.svelte
@@ -11,7 +11,9 @@
 	export type ColorValueRgbObject = Simplify<RgbColorObject>
 	export type ColorValueRgbaObject = Simplify<RgbaColorObject>
 	export type ColorValueString = string
+	export type ColorValueNumber = number
 	export type ColorValue = Simplify<
+		| ColorValueNumber
 		| ColorValueRgbaObject
 		| ColorValueRgbaTuple
 		| ColorValueRgbObject
@@ -22,7 +24,7 @@
 	export type ColorChangeEvent = ValueChangeEvent<ColorValue>
 </script>
 
-<script lang="ts">
+<script generics="T extends ColorValue" lang="ts">
 	import type { ComponentProps } from 'svelte'
 	import type { ColorInputParams as ColorOptions, InputBindingApi as ColorRef } from 'tweakpane'
 	import { isColorObject, isRgbaColorObject, isRgbColorObject } from '@tweakpane/core'
@@ -30,36 +32,68 @@
 	import { shallowEqual } from 'fast-equals'
 	import ClsPad from '$lib/internal/ClsPad.svelte'
 	import GenericInputFolding from '$lib/internal/GenericInputFolding.svelte'
-	import { fillWith, objectToTuple } from '$lib/utils.js'
+	import { fillWith, objectToTuple, removeKeys } from '$lib/utils.js'
 
-	type ColorValueInternal = ColorValueRgbaObject | ColorValueRgbObject | ColorValueString
+	type ColorValueInternal =
+		| ColorValueNumber
+		| ColorValueRgbaObject
+		| ColorValueRgbObject
+		| ColorValueString
+
+	type PropsForType<U> = U extends ColorValueNumber
+		? {
+				/**
+				 * Whether to treat the number value as carrying an alpha component
+				 * in its lowest byte (e.g. `0xff00667f`).
+				 *
+				 * Only available when `value` is a number, since string, object,
+				 * and tuple values carry their own alpha information.
+				 *
+				 * @default `false`
+				 */
+				alpha?: boolean
+			}
+		: unknown
 
 	type $$Props = Omit<
-		ComponentProps<GenericInputFolding<ColorValue, ColorOptions>>,
+		ComponentProps<GenericInputFolding<T, ColorOptions>>,
 		'buttonClass' | 'options' | 'plugin' | 'ref'
-	> & {
-		/**
-		 * A color value to control.
-		 *
-		 * Use either a color-like string (e.g. #ff00ff), or an object with `r`,
-		 * `b`, `g`, and optional `a` keys.
-		 *
-		 * @bindable
-		 */
-		value: ColorValue
-		/**
-		 * Whether to treat values as floats from 0.0 to 1.0, or integers from 0 to
-		 * 255.
-		 *
-		 * @default `'int'`
-		 */
-		type?: 'float' | 'int'
-	}
+	> &
+		PropsForType<T> & {
+			/**
+			 * A color value to control.
+			 *
+			 * Use either a color-like string (e.g. #ff00ff), a number (e.g.
+			 * 0xff00ff), an object with `r`, `b`, `g`, and optional `a` keys, or a
+			 * tuple.
+			 *
+			 * The type of this value will determine the availability of the
+			 * `alpha` prop.
+			 *
+			 * @bindable
+			 */
+			value: T
+			/**
+			 * Whether to treat values as floats from 0.0 to 1.0, or integers from
+			 * 0 to 255.
+			 *
+			 * Number values are always treated as integers.
+			 *
+			 * @default `'int'`
+			 */
+			type?: 'float' | 'int'
+		}
 
 	// Must redeclare for bindability
-	export let value: $$Props['value']
-	export let expanded: $$Props['expanded'] = undefined
-	export let type: $$Props['type'] = undefined
+	// Concrete types instead of $$Props indexes to work around deferred
+	// conditional type resolution, see similar in Point.svelte
+	export let value: T
+	export let expanded: boolean | undefined = undefined
+	export let type: 'float' | 'int' | undefined = undefined
+
+	// Dynamic non-bindable prop, only available for number values
+	let alpha: boolean | undefined
+	$: alpha = ($$props['alpha'] as boolean | undefined) ?? undefined
 
 	// Inheriting here with ComponentEvents makes a documentation mess
 
@@ -90,8 +124,8 @@
 
 	function updateInternalValueFromValue() {
 		// External value can change internal type on the fly, but internal value can never change external value type!
-		// Internal value must be string or object for Tweakpane compatibility
-		if (typeof value === 'string') {
+		// Internal value must be a string, number, or object for Tweakpane compatibility
+		if (typeof value === 'string' || typeof value === 'number') {
 			if (internalValue !== value) {
 				internalValue = value
 			}
@@ -117,9 +151,13 @@
 	}
 
 	function updateValueFromInternalValue() {
-		if (typeof value === 'string' && typeof internalValue === 'string') {
+		if (
+			(typeof value === 'string' && typeof internalValue === 'string') ||
+			(typeof value === 'number' && typeof internalValue === 'number')
+		) {
 			if (internalValue !== value) {
-				value = internalValue
+				// eslint-disable-next-line ts/no-unnecessary-type-assertion
+				value = internalValue as T
 			}
 		} else if (Array.isArray(value) && isColorObject(internalValue)) {
 			const newValue = isRgbaColorObject(internalValue)
@@ -131,25 +169,24 @@
 			if (newValue === undefined) {
 				console.error('Unreachable color type mismatch')
 			} else if (!shallowEqual(newValue, value)) {
-				value = newValue
+				// eslint-disable-next-line ts/no-unnecessary-type-assertion
+				value = newValue as T
 			}
 		} else if (isColorObject(value) && isColorObject(internalValue)) {
 			if (!shallowEqual(internalValue, value)) {
-				value = { ...internalValue }
+				// eslint-disable-next-line ts/no-unnecessary-type-assertion
+				value = { ...internalValue } as T
 			}
 		} else {
 			console.error('Unreachable color type mismatch')
 		}
 	}
 
-	// TODO does this do anything? passing channel like 0x00ffd644 adds alpha automatically setting
-	// alpha to true on 0x00ffd6 doesn't add the control... were these both deprecated in 4.0?
-	// https://github.com/cocopon/tweakpane/issues/450 options.color.alpha, options.color.type
-
 	$: (value, updateInternalValueFromValue())
 	$: (internalValue, updateValueFromInternalValue())
 	$: options = {
 		color: {
+			alpha,
 			type,
 		},
 		view: 'color',
@@ -161,6 +198,9 @@
 A color picker.
 
 Wraps Tweakpane's [color input binding](https://tweakpane.github.io/docs/input-bindings/#color).
+
+`<Color>` is a dynamic component, and the `alpha` prop is only available when `value` is a number.
+(Other value types carry their own alpha information.)
 
 Usage outside of a `<Pane>` component will implicitly wrap the color picker in `<Pane
 position="inline">`.
@@ -201,13 +241,13 @@ position="inline">`.
 	bind:expanded
 	bind:ref
 	on:change
-	{...$$restProps}
+	{...removeKeys($$restProps, 'alpha')}
 />
 {#if !BROWSER && expanded && $$props.picker === 'inline'}
 	<!-- Main swatch -->
 	<ClsPad keysAdd={fillWith('containerUnitSize', 6)} theme={$$props.theme} />
 	<ClsPad keysAdd={fillWith('containerUnitSpacing', 3)} theme={$$props.theme} />
-	{#if isRgbaColorObject(internalValue)}
+	{#if alpha === true || isRgbaColorObject(internalValue)}
 		<ClsPad keysAdd={fillWith('containerUnitSize', 1)} theme={$$props.theme} />
 		<ClsPad extra={2} keysAdd={fillWith('containerVerticalPadding', 2)} theme={$$props.theme} />
 	{/if}

--- a/src/lib/control/Color.svelte
+++ b/src/lib/control/Color.svelte
@@ -5,7 +5,6 @@
 	} from '@tweakpane/core/dist/input-binding/color/model/color.js'
 	import type { Simplify, ValueChangeEvent } from '$lib/utils.js'
 
-	// TODO tuples, oklch, etc TODO set default picker mode between rgb, hsl, etc.?
 	export type ColorValueRgbTuple = [r: number, g: number, b: number]
 	export type ColorValueRgbaTuple = [r: number, g: number, b: number, a: number]
 	export type ColorValueRgbObject = Simplify<RgbColorObject>
@@ -35,25 +34,16 @@
 	import { fillWith, objectToTuple, removeKeys } from '$lib/utils.js'
 
 	type ColorValueInternal =
-		| ColorValueNumber
-		| ColorValueRgbaObject
-		| ColorValueRgbObject
-		| ColorValueString
+		ColorValueNumber | ColorValueRgbaObject | ColorValueRgbObject | ColorValueString
 
 	type ColorValueObjectOrTuple =
-		| ColorValueRgbaObject
-		| ColorValueRgbaTuple
-		| ColorValueRgbObject
-		| ColorValueRgbTuple
+		ColorValueRgbaObject | ColorValueRgbaTuple | ColorValueRgbObject | ColorValueRgbTuple
 
 	type PropsForType<U> = (U extends ColorValueNumber
 		? {
 				/**
-				 * Whether to treat the number value as carrying an alpha component
-				 * in its lowest byte (e.g. `0xff00667f`).
-				 *
-				 * Only available when `value` is a number, since string, object,
-				 * and tuple values carry their own alpha information.
+				 * Whether to treat a `number` value as carrying an alpha component in
+				 * its lowest byte (e.g. `0xff00667f`).
 				 *
 				 * @default `false`
 				 */
@@ -63,12 +53,8 @@
 		(U extends ColorValueObjectOrTuple
 			? {
 					/**
-					 * Whether to treat values as floats from 0.0 to 1.0, or integers
-					 * from 0 to 255.
-					 *
-					 * Only available when `value` is an object or tuple, since
-					 * strings carry their own type information and numbers are
-					 * always treated as integers.
+					 * Whether to treat `object` or `tuple` values as floats from 0.0 to
+					 * 1.0, or integers from 0 to 255.
 					 *
 					 * @default `'int'`
 					 */
@@ -88,8 +74,8 @@
 			 * 0xff00ff), an object with `r`, `b`, `g`, and optional `a` keys, or a
 			 * tuple.
 			 *
-			 * The type of this value will determine the availability of the
-			 * `alpha` and `type` props.
+			 * The type of this value will determine the availability of the `alpha`
+			 * and `type` props.
 			 *
 			 * @bindable
 			 */

--- a/src/lib/control/Color.svelte
+++ b/src/lib/control/Color.svelte
@@ -40,7 +40,13 @@
 		| ColorValueRgbObject
 		| ColorValueString
 
-	type PropsForType<U> = U extends ColorValueNumber
+	type ColorValueObjectOrTuple =
+		| ColorValueRgbaObject
+		| ColorValueRgbaTuple
+		| ColorValueRgbObject
+		| ColorValueRgbTuple
+
+	type PropsForType<U> = (U extends ColorValueNumber
 		? {
 				/**
 				 * Whether to treat the number value as carrying an alpha component
@@ -53,7 +59,22 @@
 				 */
 				alpha?: boolean
 			}
-		: unknown
+		: unknown) &
+		(U extends ColorValueObjectOrTuple
+			? {
+					/**
+					 * Whether to treat values as floats from 0.0 to 1.0, or integers
+					 * from 0 to 255.
+					 *
+					 * Only available when `value` is an object or tuple, since
+					 * strings carry their own type information and numbers are
+					 * always treated as integers.
+					 *
+					 * @default `'int'`
+					 */
+					type?: 'float' | 'int'
+				}
+			: unknown)
 
 	type $$Props = Omit<
 		ComponentProps<GenericInputFolding<T, ColorOptions>>,
@@ -68,20 +89,11 @@
 			 * tuple.
 			 *
 			 * The type of this value will determine the availability of the
-			 * `alpha` prop.
+			 * `alpha` and `type` props.
 			 *
 			 * @bindable
 			 */
 			value: T
-			/**
-			 * Whether to treat values as floats from 0.0 to 1.0, or integers from
-			 * 0 to 255.
-			 *
-			 * Number values are always treated as integers.
-			 *
-			 * @default `'int'`
-			 */
-			type?: 'float' | 'int'
 		}
 
 	// Must redeclare for bindability
@@ -89,11 +101,12 @@
 	// conditional type resolution, see similar in Point.svelte
 	export let value: T
 	export let expanded: boolean | undefined = undefined
-	export let type: 'float' | 'int' | undefined = undefined
 
-	// Dynamic non-bindable prop, only available for number values
+	// Dynamic non-bindable props, availability gated on the type of `value`
 	let alpha: boolean | undefined
 	$: alpha = ($$props['alpha'] as boolean | undefined) ?? undefined
+	let type: 'float' | 'int' | undefined
+	$: type = ($$props['type'] as 'float' | 'int' | undefined) ?? undefined
 
 	// Inheriting here with ComponentEvents makes a documentation mess
 
@@ -199,8 +212,9 @@ A color picker.
 
 Wraps Tweakpane's [color input binding](https://tweakpane.github.io/docs/input-bindings/#color).
 
-`<Color>` is a dynamic component, and the `alpha` prop is only available when `value` is a number.
-(Other value types carry their own alpha information.)
+`<Color>` is a dynamic component: the `alpha` prop is only available when `value` is a number, and
+the `type` prop is only available when `value` is an object or tuple. (Other value types carry
+their own alpha and type information.)
 
 Usage outside of a `<Pane>` component will implicitly wrap the color picker in `<Pane
 position="inline">`.
@@ -241,7 +255,7 @@ position="inline">`.
 	bind:expanded
 	bind:ref
 	on:change
-	{...removeKeys($$restProps, 'alpha')}
+	{...removeKeys($$restProps, 'alpha', 'type')}
 />
 {#if !BROWSER && expanded && $$props.picker === 'inline'}
 	<!-- Main swatch -->

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -15,6 +15,7 @@ export { default as Color } from '$lib/control/Color.svelte'
 export type {
 	ColorChangeEvent,
 	ColorValue,
+	ColorValueNumber,
 	ColorValueRgbaObject,
 	ColorValueRgbaTuple,
 	ColorValueRgbObject,

--- a/tests/components/control/color.spec.ts
+++ b/tests/components/control/color.spec.ts
@@ -21,6 +21,30 @@ test.describe('Color component', () => {
 		})
 	})
 
+	test.describe('number values', () => {
+		test('number-bound picker renders and expands', async ({ page }) => {
+			await page.goto('/TestColor.svelte')
+
+			const row = page.locator('.tp-lblv').filter({ hasText: 'Binding 5' })
+			await row.locator('.tp-colswv').click()
+			await expect(row.locator('.tp-colv')).toBeVisible()
+		})
+
+		test('alpha prop adds an alpha slider for number values', async ({ page }) => {
+			await page.goto('/TestColor.svelte')
+
+			const withAlpha = page.locator('.tp-lblv').filter({ hasText: 'Binding 6' })
+			await withAlpha.locator('.tp-colswv').click()
+			await expect(withAlpha.locator('.tp-colv')).toBeVisible()
+			await expect(withAlpha.locator('.tp-aplv')).toHaveCount(1)
+
+			const withoutAlpha = page.locator('.tp-lblv').filter({ hasText: 'Binding 5' })
+			await withoutAlpha.locator('.tp-colswv').click()
+			await expect(withoutAlpha.locator('.tp-colv')).toBeVisible()
+			await expect(withoutAlpha.locator('.tp-aplv')).toHaveCount(0)
+		})
+	})
+
 	test.describe('change events', () => {
 		test('changing color fires internal event', async ({ page }) => {
 			await page.goto('/TestColor.svelte')


### PR DESCRIPTION
Somehow support for numeric color values was never implemented in _Svelte Tweakpane UI_ even though it's supported in vanilla Tweakpane.

This PR also adds support for the `alpha` prop, which wasn't previously necessary since it only applies to numeric types.

The dynamic nature of the `alpha` (and `type`) props has [caused some confusion](https://github.com/cocopon/tweakpane/issues/626) for users in the past, so `<Color>` is now configured as a dynamic prop component, and only enables the `alpha` and `type` props when appropriate for the value type.

This technically isn't a breaking change, but it will introduce type errors for any users who have been using the `type` prop with a `string` color value. (Which has always been a no-op on Tweakpane's side.)