### PR TITLE
feat: Exclusive folder expansion

### DIFF
--- a/docs/src/content/docs/docs/features.mdx
+++ b/docs/src/content/docs/docs/features.mdx
@@ -76,7 +76,11 @@ Folders and inline pickers inside a draggable `<Pane>` can be set to automatical
 
 ### Control user collapsibility
 
-If you want to prevent the user from collapsing chunk of pane, you can set the `userExpandable` prop to `false`. The section will remain programmatically collapsible via the `expanded` property.
+If you want to prevent the user from collapsing a `<Pane>`, `<Folder>`, or any folding control, you can set the `userExpandable` prop to `false`. The section will remain programmatically collapsible via the `expanded` property.
+
+### Exclusive expansion
+
+Holding <kbd>⌥ Option</kbd> (<kbd>Alt</kbd>) while clicking a `<Folder>`'s title bar makes it the only expanded folder at its level: sibling folders collapse, and the clicked folder expands or stays open. Folders that are `disabled` or have `userExpandable` set to `false` are unaffected.
 
 ### Label truncation
 

--- a/src/examples/tests/TestFolderExclusiveExpansion.svelte
+++ b/src/examples/tests/TestFolderExclusiveExpansion.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+	import { Checkbox, Folder, Pane } from '$lib'
+	let expandedA = true
+	let expandedB = true
+	let expandedC = true
+	let expandedNested = true
+	let expandedLocked = true
+	let expandedDisabled = true
+</script>
+
+<Pane position="inline" title="Alt Click Test">
+	<Folder title="Folder A" bind:expanded={expandedA}>
+		<Checkbox label="A" value={true} />
+	</Folder>
+	<Folder title="Folder B" bind:expanded={expandedB}>
+		<Checkbox label="B" value={true} />
+		<Folder title="Nested B1" bind:expanded={expandedNested}>
+			<Checkbox label="B1" value={true} />
+		</Folder>
+	</Folder>
+	<Folder title="Folder C" bind:expanded={expandedC}>
+		<Checkbox label="C" value={true} />
+	</Folder>
+	<Folder title="Locked" userExpandable={false} bind:expanded={expandedLocked}>
+		<Checkbox label="L" value={true} />
+	</Folder>
+	<Folder disabled title="Disabled" bind:expanded={expandedDisabled}>
+		<Checkbox label="D" value={true} />
+	</Folder>
+</Pane>
+
+<p id="state">
+	{expandedA}
+	{expandedB}
+	{expandedC}
+	{expandedNested}
+	{expandedLocked}
+	{expandedDisabled}
+</p>

--- a/src/lib/core/Folder.svelte
+++ b/src/lib/core/Folder.svelte
@@ -86,6 +86,37 @@
 		})
 
 		folderRef = $folderStore
+		$folderStore.controller.view.buttonElement.addEventListener('click', handleTitleBarClick)
+	}
+
+	function handleTitleBarClick(event: MouseEvent) {
+		// Alt-click gives exclusive "accordion" behavior: the clicked folder
+		// becomes the only open folder at its level
+		if (folderRef === undefined || $parentStore === undefined || !event.altKey) {
+			return
+		}
+
+		for (const sibling of $parentStore.children) {
+			if (sibling === folderRef || !('expanded' in sibling)) {
+				continue
+			}
+
+			// Skip folders the user couldn't reopen by clicking, checking DOM
+			// state set by updateCollapsibility and Tweakpane itself
+			const titleBarElement = sibling.element.querySelector<HTMLButtonElement>('.tp-fldv_b')
+			if (
+				titleBarElement !== null &&
+				!titleBarElement.disabled &&
+				titleBarElement.dataset.userExpandable !== 'false'
+			) {
+				;(sibling as FolderRef).expanded = false
+			}
+		}
+
+		// Tweakpane's own toggle already ran by the time this handler is called,
+		// so reopen the folder if the click closed it... alt-click never
+		// collapses its target
+		folderRef.expanded = true
 	}
 
 	onMount(() => {
@@ -93,6 +124,7 @@
 	})
 
 	onDestroy(() => {
+		folderRef?.controller.view.buttonElement.removeEventListener('click', handleTitleBarClick)
 		$folderStore?.dispose()
 	})
 
@@ -117,6 +149,10 @@ Wraps the Tweakpane [`addFolder`](https://tweakpane.github.io/docs/ui-components
 
 May also be used to label and group multiple controls without user-collapsibility by setting
 `userExpandable` to `false` and `expanded` to true.
+
+Holding <kbd>⌥ Option</kbd> (<kbd>Alt</kbd>) while clicking a folder's title bar makes it the
+only expanded folder at its level: sibling folders collapse, and the clicked folder expands or
+stays open. Siblings that are `disabled` or have `userExpandable` set to `false` are unaffected.
 
 Usage outside of a `<Pane>` component will implicitly wrap the folder in `<Pane position="inline">`.
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -208,6 +208,10 @@ export function updateCollapsibility(
 		const titleBarElement = element.querySelector<HTMLButtonElement>(`.${titleBarClass}`)
 
 		if (titleBarElement) {
+			// Lets the alt-click accordion handler in Folder.svelte check a
+			// sibling's user-expandability at click time
+			titleBarElement.dataset.userExpandable = String(isUserExpandableEnabled)
+
 			const iconElement =
 				iconClass === undefined || iconClass === ''
 					? undefined

--- a/tests/components/core/folder.spec.ts
+++ b/tests/components/core/folder.spec.ts
@@ -1,4 +1,7 @@
+import type { Page } from '@playwright/test'
 import { expect, test } from '@playwright/test'
+
+const expandedClass = /tp-fldv-expanded/v
 
 test.describe('Folder component', () => {
 	test.describe('visibility', () => {
@@ -16,6 +19,58 @@ test.describe('Folder component', () => {
 
 			// Find a folder element by its title
 			await expect(page.locator('.tp-rotv_t').first()).toBeVisible()
+		})
+	})
+
+	test.describe('alt-click exclusive expansion', () => {
+		// Title bar button of the folder with the given title
+		const titleBar = (page: Page, title: string) => page.locator('.tp-fldv_b', { hasText: title })
+		// Root element of the folder with the given title (expanded state is
+		// reflected in its tp-fldv-expanded class)
+		const folder = (page: Page, title: string) => page.locator('.tp-fldv', { hasText: title })
+		// Renders the expanded bindings as 'A B C Nested Locked Disabled'
+		const state = (page: Page) => page.locator('#state')
+
+		test.beforeEach(async ({ page }) => {
+			await page.goto('/TestFolderExclusiveExpansion.svelte')
+			await expect(state(page)).toHaveText('true true true true true true')
+		})
+
+		test('plain click collapses only the clicked folder', async ({ page }) => {
+			await titleBar(page, 'Folder A').click()
+
+			await expect(state(page)).toHaveText('false true true true true true')
+			await expect(folder(page, 'Folder B')).toHaveClass(expandedClass)
+			await expect(folder(page, 'Folder C')).toHaveClass(expandedClass)
+		})
+
+		test('alt-click on an open folder collapses siblings and keeps it open', async ({ page }) => {
+			await titleBar(page, 'Folder A').click({ modifiers: ['Alt'] })
+
+			// A stays open, B and C collapse, nested and non-user-expandable
+			// folders are untouched
+			await expect(state(page)).toHaveText('true false false true true true')
+			await expect(folder(page, 'Folder A')).toHaveClass(expandedClass)
+			await expect(folder(page, 'Folder B')).not.toHaveClass(expandedClass)
+			await expect(folder(page, 'Folder C')).not.toHaveClass(expandedClass)
+			await expect(folder(page, 'Locked')).toHaveClass(expandedClass)
+			await expect(folder(page, 'Disabled')).toHaveClass(expandedClass)
+		})
+
+		test('alt-click on a closed folder opens it and collapses siblings', async ({ page }) => {
+			await titleBar(page, 'Folder A').click()
+			await expect(state(page)).toHaveText('false true true true true true')
+
+			await titleBar(page, 'Folder A').click({ modifiers: ['Alt'] })
+
+			await expect(state(page)).toHaveText('true false false true true true')
+			await expect(folder(page, 'Folder A')).toHaveClass(expandedClass)
+		})
+
+		test('alt-click on a non-user-expandable folder does nothing', async ({ page }) => {
+			await titleBar(page, 'Locked').click({ modifiers: ['Alt'] })
+
+			await expect(state(page)).toHaveText('true true true true true true')
 		})
 	})
 })


### PR DESCRIPTION
Option-click (or alt-click) a folder's title bars to "solo" that folder and collapse any open siblings.

Useful when you have many folders and want to focus on a single one.